### PR TITLE
支持没有配置ResultMap的字段进行分页筛选

### DIFF
--- a/src/main/java/org/yelog/soultable/util/SoulTableInterceptor.java
+++ b/src/main/java/org/yelog/soultable/util/SoulTableInterceptor.java
@@ -106,7 +106,7 @@ public class SoulTableInterceptor implements Interceptor {
 
                     // 排序
                     if (StringUtils.isNotBlank(soulPage.getField())) {
-                        filterSql.append(" order by ").append(fieldMap.size() > 0 ? fieldMap.get(soulPage.getField()) : soulPage.getField()).append(" ").append(soulPage.getOrder());
+                        filterSql.append(" order by ").append(fieldMap.size() > 0 ? (fieldMap.get(soulPage.getField()) != null ? fieldMap.get(soulPage.getField()) : soulPage.getField()) : soulPage.getField()).append(" ").append(soulPage.getOrder());
                     }
 
                     if (soulPage.getLimit()==100000000) {

--- a/src/main/java/org/yelog/soultable/util/SoulTableInterceptor.java
+++ b/src/main/java/org/yelog/soultable/util/SoulTableInterceptor.java
@@ -154,7 +154,7 @@ public class SoulTableInterceptor implements Interceptor {
             filterSql.append(StringUtils.isBlank(filterSo.getPrefix())?" and":" "+filterSo.getPrefix());
         }
 
-        String field = fieldMap.size()>0?fieldMap.get(filterSo.getField()):filterSo.getField();
+        String field = fieldMap.size()>0? (fieldMap.get(filterSo.getField()) != null ? fieldMap.get(filterSo.getField()) : filterSo.getField()) :filterSo.getField();
         String value = filterSo.getValue();
         switch (filterSo.getMode()) {
             case "in":


### PR DESCRIPTION
原代码逻辑是从mapper.xml中获取配置的ResultMap中的字段，如果没有配置则fieldMap中没有该key，get这个key的时候返回的就是null，这样拼接出来的SQL语句就有问题。加多个判断即可，如果ResultMap中没有配置字段，则直接从请求中获取字段名